### PR TITLE
ubuntu-core-initramfs: run cpio with subprocess.run()

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -78,12 +78,14 @@ def create_initrd(parser, args):
             for early in glob.iglob("%s/early/*.cpio" % args.skeleton):
                 with open(early, "rb") as f:
                     shutil.copyfileobj(f, output)
-            subprocess.check_call(
-                "find . | cpio --create --quiet --format='newc' --owner=0:0 | lz4 -9 -l",
-                cwd=main,
-                shell=True,
-                stdout=output,
-            )
+            output.write(
+                subprocess.run(
+                    "find . | cpio --create --quiet --format='newc' --owner=0:0 | lz4 -9 -l",
+                    cwd=main,
+                    capture_output=True,
+                    shell=True,
+                    check=True,
+                ).stdout)
 
 
 def create_efi(parser, args):


### PR DESCRIPTION
It has been found that in the x86 case (that prepends an early
initramfs with microcode files), the created initramfs was in some
cases not correct, and the kernel was unable to load it. Looking at
python dcoumentation about subprocess.check_call() [1], it says

"Code needing to capture stdout or stderr should use run() instead"

And it turns out that capturing output from run() fixes the problem,
although it is unclear what is the problem.