### PR TITLE
tests: Be more verbose when nested VM does not respond

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -174,6 +174,9 @@ start_nested_core_vm_unit(){
 
     # Wait until ssh is ready
     if ! wait_for_ssh "${SVC_NAME}"; then
+        echo "===== SERIAL PORT OUTPUT ======" 1>&2
+        cat "${WORK_DIR}/serial.log" 1>&2
+        echo "===== END OF SERIAL PORT OUTPUT ======" 1>&2
         return 1
     fi
 }


### PR DESCRIPTION
This prints the output of the serial port if we were unable to
connect through ssh to the VM.