### PR TITLE
core22: move linux-firmware to Recommends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-core-initramfs (66.8) jammy; urgency=medium
+
+  * Set linux-firmware as recommended package
+
+ -- Ondrej Kubik <ondrej.kubik@canonical.com>  Fri, 02 Aug 2024 13:30:44 +0100
+
 ubuntu-core-initramfs (66.7) jammy; urgency=medium
 
   * No change rebuild to take latest versions of packages in

--- a/debian/control
+++ b/debian/control
@@ -76,7 +76,8 @@ Homepage: https://launchpad.net/ubuntu-core-initramfs
 
 Package: ubuntu-core-initramfs
 Architecture: amd64 arm64 armhf riscv64
-Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, snapd (>= 2.50+20.04), linux-firmware, llvm, kcapi-tools
+Depends: ${python3:Depends}, ${misc:Depends}, dracut-core (>= 051-1), zstd, sbsigntool, snapd (>= 2.50+20.04), llvm, kcapi-tools
+Recommends: linux-firmware
 Description: standard embedded initrd
  Standard embedded initrd implementation to be used with Ubuntu Core
  systems. Currently targetting creating BLS Type2 like binaries.


### PR DESCRIPTION
There are use-cases when the firmware is customised or pulled from
the custom packages, so installing linux-firmware is unnecessary.
Considering the size of the package, it is better set as "Recommends"
The prime use case is when building kernel snap package locally, firmware staged to the snap should be used  as a primarily source of truth.