### PR TITLE
factory: mount users imported from hybrid system during recovery mode

### DIFF
--- a/factory/usr/lib/core/extra-paths
+++ b/factory/usr/lib/core/extra-paths
@@ -20,3 +20,17 @@ if [ ! -d /run/mnt/data/system-data/var/lib/snapd/kernel/"$kernelName"/"$rev" ];
 /run/mnt/kernel/modules /usr/lib/modules none bind,x-initrd.mount 0 0
 EOF
 fi
+
+# in recovery mode on hybrid systems, snap-bootstrap generates passwd, shadow,
+# group, and gshadow files in /run/snapd/hybrid-users. these files contain users
+# imported from the host system mixed with the default users from the base snap
+# that is used for recovery mode.
+mode="$(/usr/libexec/core/get-mode mode)" || mode="$(/usr/libexec/core/get-arg snapd_recovery_mode)" || mode="unknown"
+if [ -f /run/snapd/hybrid-users/passwd ] && [ "${mode}" = "recover" ]; then
+    cat <<'EOF' >>/sysroot/etc/fstab
+/run/snapd/hybrid-users/passwd /etc/passwd none bind 0 0
+/run/snapd/hybrid-users/shadow /etc/shadow none bind 0 0
+/run/snapd/hybrid-users/group /etc/group none bind 0 0
+/run/snapd/hybrid-users/gshadow /etc/gshadow none bind 0 0
+EOF
+fi


### PR DESCRIPTION
These files are generated by snap-bootstrap when booting a hybrid system into recovery mode. The files contain a combination of the login information from the hybrid rootfs and the base.