### PR TITLE
factory: do not use overrides for /lib/{modules,firmware} mounts

### DIFF
--- a/factory/usr/lib/core/extra-paths
+++ b/factory/usr/lib/core/extra-paths
@@ -6,8 +6,8 @@ cat <<'EOF' >>/sysroot/etc/fstab
 /run/mnt/data /writable none bind,x-initrd.mount 0 0
 EOF
 
-# Find out kernel name / revision
-kernelPath=$(cat /sys/dev/block/"$(mountpoint --fs-devno /run/mnt/kernel)"/loop/backing_file)
+# Find out kernel name / revision, exit if not mounted
+kernelPath=$(cat /sys/dev/block/"$(mountpoint --fs-devno /run/mnt/kernel)"/loop/backing_file) || exit 0
 kernelFile=$(basename "$kernelPath")
 kernelName=${kernelFile%%_*}
 rev=${kernelFile#*_}
@@ -19,4 +19,14 @@ if [ ! -d /run/mnt/data/system-data/var/lib/snapd/kernel/"$kernelName"/"$rev" ];
 /run/mnt/kernel/firmware /usr/lib/firmware none bind,x-initrd.mount 0 0
 /run/mnt/kernel/modules /usr/lib/modules none bind,x-initrd.mount 0 0
 EOF
+    for subdir in firmware modules; do
+        drop_d=/etc/systemd/system/sysroot-usr-lib-"$subdir".mount.d
+        mkdir -p "$drop_d"
+        cat <<EOF >"$drop_d"/what.conf
+[Mount]
+# systemd-fstab-generator tries to be smart and uses
+# /sysroot/run/mnt/kernel/$subdir, so we need to set the path
+What=/run/mnt/kernel/$subdir
+EOF
+    done
 fi

--- a/factory/usr/lib/systemd/system/sysroot-usr-lib-firmware.mount.d/what.conf
+++ b/factory/usr/lib/systemd/system/sysroot-usr-lib-firmware.mount.d/what.conf
@@ -1,4 +1,0 @@
-[Mount]
-# systemd-fstab-generator tries to be smart and uses
-# /sysroot/run/mnt/kernel/firmware, so we need to set the path
-What=/run/mnt/kernel/firmware

--- a/factory/usr/lib/systemd/system/sysroot-usr-lib-modules.mount.d/what.conf
+++ b/factory/usr/lib/systemd/system/sysroot-usr-lib-modules.mount.d/what.conf
@@ -1,4 +1,0 @@
-[Mount]
-# systemd-fstab-generator tries to be smart and uses
-# /sysroot/run/mnt/kernel/modules, so we need to set the path
-What=/run/mnt/kernel/modules


### PR DESCRIPTION
as this can override also mount units generated when we do have a drivers tree. Also, prevent crashing if the kernel has not been mounted in /run/mnt/kernel.