### PR TITLE
factory: change checks for UC/classic

### DIFF
--- a/factory/usr/lib/systemd/system/detect-classic-sysroot.service
+++ b/factory/usr/lib/systemd/system/detect-classic-sysroot.service
@@ -1,3 +1,5 @@
+# TODO remove this unit once snap-bootstrap starts
+# to mount the base directly to sysroot.
 [Unit]
 Description=Detect Ubuntu classic sysroot
 DefaultDependencies=no

--- a/factory/usr/lib/systemd/system/detect-uc-sysroot.service
+++ b/factory/usr/lib/systemd/system/detect-uc-sysroot.service
@@ -1,3 +1,5 @@
+# TODO remove this unit once snap-bootstrap starts
+# to mount the base directly to sysroot.
 [Unit]
 Description=Detect Ubuntu Core sysroot
 DefaultDependencies=no

--- a/factory/usr/lib/systemd/system/plymouth-for-classic.service
+++ b/factory/usr/lib/systemd/system/plymouth-for-classic.service
@@ -7,7 +7,7 @@ ConditionKernelCommandLine=!plymouth.enable=0
 ConditionKernelCommandLine=!nosplash
 ConditionKernelCommandLine=splash
 ConditionVirtualization=!container
-ConditionPathIsMountPoint=!/run/mnt/base
+ConditionPathIsDirectory=!/run/mnt/data/system-data
 
 [Service]
 Type=oneshot

--- a/factory/usr/lib/systemd/system/plymouth-for-core.service
+++ b/factory/usr/lib/systemd/system/plymouth-for-core.service
@@ -7,7 +7,7 @@ ConditionKernelCommandLine=!plymouth.enable=0
 ConditionKernelCommandLine=!nosplash
 ConditionKernelCommandLine=splash
 ConditionVirtualization=!container
-ConditionPathIsMountPoint=/run/mnt/base
+ConditionPathIsDirectory=/run/mnt/data/system-data
 
 [Service]
 Type=oneshot

--- a/factory/usr/lib/systemd/system/populate-writable.service
+++ b/factory/usr/lib/systemd/system/populate-writable.service
@@ -12,7 +12,7 @@ Requires=sysroot-writable.mount
 Wants=snap-initramfs-mounts.service
 After=snap-initramfs-mounts.service
 
-ConditionPathIsMountPoint=/run/mnt/base
+ConditionPathIsDirectory=/run/mnt/data/system-data
 
 [Service]
 Type=oneshot

--- a/factory/usr/lib/systemd/system/sysroot-writable.mount
+++ b/factory/usr/lib/systemd/system/sysroot-writable.mount
@@ -9,7 +9,7 @@ After=run-mnt-data.mount
 After=run-mnt-base.mount
 After=snap-initramfs-mounts.service
 
-ConditionPathIsMountPoint=/run/mnt/base
+ConditionPathIsDirectory=/run/mnt/data/system-data
 
 [Mount]
 What=/run/mnt/data

--- a/factory/usr/lib/systemd/system/sysroot.mount
+++ b/factory/usr/lib/systemd/system/sysroot.mount
@@ -1,3 +1,5 @@
+# TODO remove once snap-bootstrap writing this unit
+# in /run lands.
 [Unit]
 DefaultDependencies=no
 Before=initrd-root-fs.target


### PR DESCRIPTION
In a near future snap-bootstrap will not mount the base anymore in /run/mnt/base and instead it will create a unit to mount it directly to /sysroot. Therefore, change the checks to know if this is UC or classic to finding out if /run/mnt/data/system-data exists instead of looking at /run/mnt/base.