### PR TITLE
EFI stub: Relocate kernel image to allocate space for BSS

### DIFF
--- a/vendor/systemd-patches/0074-relocate-kernel-image-to-allocate-space-for-BSS.patch
+++ b/vendor/systemd-patches/0074-relocate-kernel-image-to-allocate-space-for-BSS.patch
@@ -1,0 +1,113 @@
+Index: systemd/src/boot/efi/linux_x86.c
+===================================================================
+--- systemd.orig/src/boot/efi/linux_x86.c	2024-09-26 15:38:46.938310743 -0300
++++ systemd/src/boot/efi/linux_x86.c	2024-09-26 17:41:15.335495467 -0300
+@@ -16,6 +16,7 @@
+ #include "initrd.h"
+ #include "linux.h"
+ #include "macro-fundamental.h"
++#include "pe.h"
+ #include "util.h"
+ 
+ #define SETUP_MAGIC             0x53726448      /* "HdrS" */
+@@ -120,12 +121,27 @@
+         handover(image, ST, params);
+ }
+ 
++/* struct to call cleanup_pages */
++struct pages {
++        EFI_PHYSICAL_ADDRESS addr;
++        UINTN num;
++};
++
++static inline void cleanup_pages(struct pages *p) {
++        if (p->addr == 0)
++                return;
++        (void) uefi_call_wrapper(BS->FreePages, 2, p->addr, p->num);
++}
++
+ EFI_STATUS linux_exec(
+                 EFI_HANDLE image,
+                 const CHAR8 *cmdline, UINTN cmdline_len,
+                 const VOID *linux_buffer, UINTN linux_length,
+                 const VOID *initrd_buffer, UINTN initrd_length) {
+ 
++        UINT32 kernel_alignment, kernel_size_of_image;
++        _cleanup_(cleanup_pages) struct pages kernel = {};
++        VOID *new_buffer;
+         const struct boot_params *image_params;
+         struct boot_params *boot_params;
+         EFI_HANDLE initrd_handle = NULL;
+@@ -135,10 +151,39 @@
+ 
+         assert(image);
+         assert(cmdline || cmdline_len == 0);
+-        assert(linux_buffer);
++        assert(linux_buffer && linux_length > 0);
+         assert(initrd_buffer || initrd_length == 0);
+ 
+-        image_params = (const struct boot_params *) linux_buffer;
++        /* get the necessary fields from the PE header */
++        err = pe_alignment_info(linux_buffer, NULL, &kernel_size_of_image, &kernel_alignment);
++        if (EFI_ERROR(err))
++                return err;
++        /* sanity check */
++        assert(kernel_size_of_image >= linux_length);
++
++        /* Linux kernel complains if it's not loaded at a properly aligned memory address. The correct alignment
++           is provided by Linux as the SegmentAlignment in the PeOptionalHeader. Additionally the kernel needs to
++           be in a memory segment thats SizeOfImage (again from PeOptionalHeader) large, so that the Kernel has
++           space for its BSS section. SizeOfImage is always larger than linux_length, which is only the size of
++           Code, (static) Data and Headers.
++
++           Interrestingly only ARM/Aarch64 and RISC-V kernel stubs check these assertions and can even boot (with warnings)
++           if they are not met. x86 and x86_64 kernel stubs don't do checks and fail if the BSS section is too small.
++        */
++        /* allocate SizeOfImage + SectionAlignment because the new_buffer can move up to Alignment-1 bytes */
++        kernel.num = EFI_SIZE_TO_PAGES(ALIGN_TO(kernel_size_of_image, kernel_alignment) + kernel_alignment);
++        err = uefi_call_wrapper(
++                BS->AllocatePages, 4,
++                AllocateAnyPages, EfiLoaderData,
++                kernel.num, &kernel.addr);
++        if (EFI_ERROR(err))
++                return EFI_OUT_OF_RESOURCES;
++        new_buffer = PHYSICAL_ADDRESS_TO_POINTER(ALIGN_TO(kernel.addr, kernel_alignment));
++        CopyMem(new_buffer, linux_buffer, linux_length);
++        /* zero out rest of memory (probably not needed, but BSS section should be 0) */
++        SetMem((UINT8 *)new_buffer + linux_length, kernel_size_of_image - linux_length, 0);
++
++        image_params = (const struct boot_params *) new_buffer;
+ 
+         if (image_params->hdr.boot_flag != 0xAA55 ||
+             image_params->hdr.header != SETUP_MAGIC ||
+@@ -161,7 +206,7 @@
+         boot_params->hdr = image_params->hdr;
+         boot_params->hdr.type_of_loader = 0xff;
+         setup_sectors = image_params->hdr.setup_sects > 0 ? image_params->hdr.setup_sects : 4;
+-        boot_params->hdr.code32_start = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(linux_buffer) + (setup_sectors + 1) * 512;
++        boot_params->hdr.code32_start = (UINT32) POINTER_TO_PHYSICAL_ADDRESS(new_buffer) + (setup_sectors + 1) * 512;
+ 
+         if (cmdline) {
+                 addr = 0xA0000;
+Index: systemd/src/boot/efi/pe.c
+===================================================================
+--- systemd.orig/src/boot/efi/pe.c	2024-09-26 15:38:46.938310743 -0300
++++ systemd/src/boot/efi/pe.c	2024-09-26 19:28:50.350076298 -0300
+@@ -168,7 +168,6 @@
+         const struct PeFileHeader *pe;
+ 
+         assert(base);
+-        assert(ret_entry_point_address);
+         assert(ret_size_of_image);
+         assert(ret_section_alignment);
+ 
+@@ -180,7 +179,8 @@
+         if (!verify_pe(pe))
+                 return EFI_LOAD_ERROR;
+ 
+-        *ret_entry_point_address = pe->OptionalHeader.AddressOfEntryPoint;
++        if (ret_entry_point_address)
++                *ret_entry_point_address = pe->OptionalHeader.AddressOfEntryPoint;
+ 
+         if (pe->OptionalHeader.Magic == OPTHDR32_MAGIC) {
+                 *ret_size_of_image = pe->OptionalHeader.SizeOfImage;


### PR DESCRIPTION
The kernel image needs to be relocated in order to allocate enough space for the BSS. If no space is reserved for the BSS, it can overlap with the initrd in memory, causing the corruption of it.

This change uses a similar approach as taken by upsteam in:

https://github.com/systemd/systemd/pull/33882
https://github.com/systemd/systemd/issues/33816

And fixed by systemd upstream commit id 19812661f1f6 ("stub: allocate and zero enough space in legacy x86 handover protocol").

However since the base code was vastly different, this patch basically replicates the same relocation strategy used by ARM in "vendor/systemd/src/boot/efi/linux.c".

The code could have been refactored to share code with ARM, but to minimize the risk of regressions to other architectures, linux.c was left untouched.