### PR TITLE
factory: inherit keyring access for snap-bootstrap

### DIFF
--- a/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
+++ b/factory/usr/lib/systemd/system/snap-initramfs-mounts.service
@@ -16,3 +16,4 @@ RemainAfterExit=true
 ExecStart=/usr/lib/snapd/snap-bootstrap initramfs-mounts
 StandardOutput=journal+console
 StandardError=journal+console
+KeyringMode=inherit


### PR DESCRIPTION
snap-boostrap needs to manipulate the keys stored in the user keyring