### PR TITLE
bin/ubuntu-core-initramfs: add /sbin/reboot symlink

### DIFF
--- a/bin/ubuntu-core-initramfs
+++ b/bin/ubuntu-core-initramfs
@@ -488,6 +488,8 @@ def install_misc(dest_dir, sysroot):
     os.symlink("../usr/sbin/modprobe", os.path.join(dest_dir, "sbin", "modprobe"))
     # FIXME: systemd is configured with the wrong path to dmsetup
     os.symlink("../usr/sbin/dmsetup", os.path.join(dest_dir, "sbin", "dmsetup"))
+    # FIXME: snap-bootstrap uses /sbin/reboot
+    os.symlink("../usr/bin/systemctl", os.path.join(dest_dir, "sbin", "reboot"))
 
 
 class AptRepo:


### PR DESCRIPTION
snap-bootstrap needs to call /sbin/reboot in recover mode when remodeling.

Backport of https://github.com/canonical/core-initrd/pull/276