### PR TITLE
factory: symlink /etc/os-release to /etc/initrd-release

### DIFF
--- a/factory/etc/os-release
+++ b/factory/etc/os-release
@@ -1,0 +1,1 @@
+initrd-release


### PR DESCRIPTION
Add a symlink /etc/os-release pointing to /etc/initrd-release to ensure that the environment can correcly be identified by snap-bootstrap and snapd.

This also completes the recommendation described in os-release(5) regarding execution in initrd/exitrd environments.