### PR TITLE
core-initrd: adding "azure-fde" option to post installation script

### DIFF
--- a/postinst.d/ubuntu-core-initramfs
+++ b/postinst.d/ubuntu-core-initramfs
@@ -22,7 +22,7 @@ ubuntu-core-initramfs create-initrd --kernelver $version
 case `dpkg --print-architecture` in
     amd64|arm64)
 	case $version in
-	    *-azure)
+	    *-azure | *-azure-fde)
 		# Currently nullboot doesn't seal cmdline, thus it must be baked in for azure
 		ubuntu-core-initramfs create-efi --unsigned --kernelver $version --cmdline "snapd_recovery_mode=cloudimg-rootfs console=tty1 console=ttyS0 earlyprintk=ttyS0"
 		;;


### PR DESCRIPTION
"azure-fde" will become a standalone kernel, thus command line parameters must be passed to this kernel, along with regular "azure" as well to maintain backward compatibility

Backport from https://github.com/canonical/snapd/pull/14864