### PR TITLE
core-initrd: fix create-initrd default option in post installation sc…

### DIFF
--- a/postinst.d/ubuntu-core-initramfs
+++ b/postinst.d/ubuntu-core-initramfs
@@ -32,5 +32,9 @@ case `dpkg --print-architecture` in
 		ubuntu-core-initramfs create-efi --unsigned --kernelver $version
 		;;
 	esac
+	;;
+    *)
+	ubuntu-core-initramfs create-initrd --kernelver $version
+	;;
 esac
 


### PR DESCRIPTION
…ript

6a19b57415d3: "core-initrd: adding "azure-fde" option to post installation script" moved the create-initrd call into only amd64 arches, which broke arm64 and armhf use cases